### PR TITLE
Use app bindings for model classes

### DIFF
--- a/src/Contracts/Answer.php
+++ b/src/Contracts/Answer.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace MattDaneshvar\Survey\Contracts;
+
+interface Answer
+{
+    //
+}

--- a/src/Contracts/Entry.php
+++ b/src/Contracts/Entry.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace MattDaneshvar\Survey\Contracts;
+
+interface Entry
+{
+    //
+}

--- a/src/Contracts/Question.php
+++ b/src/Contracts/Question.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace MattDaneshvar\Survey\Contracts;
+
+interface Question
+{
+    //
+}

--- a/src/Contracts/Section.php
+++ b/src/Contracts/Section.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace MattDaneshvar\Survey\Contracts;
+
+interface Section
+{
+    //
+}

--- a/src/Contracts/Survey.php
+++ b/src/Contracts/Survey.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace MattDaneshvar\Survey\Contracts;
+
+interface Survey
+{
+    //
+}

--- a/src/Models/Answer.php
+++ b/src/Models/Answer.php
@@ -3,8 +3,11 @@
 namespace MattDaneshvar\Survey\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use MattDaneshvar\Survey\Contracts\Answer as AnswerContract;
+use MattDaneshvar\Survey\Contracts\Entry;
+use MattDaneshvar\Survey\Contracts\Question;
 
-class Answer extends Model
+class Answer extends Model implements AnswerContract
 {
     /**
      * Answer constructor.
@@ -34,7 +37,7 @@ class Answer extends Model
      */
     public function entry()
     {
-        return $this->belongsTo(Entry::class);
+        return $this->belongsTo(get_class(app()->make(Entry::class)));
     }
 
     /**
@@ -44,6 +47,6 @@ class Answer extends Model
      */
     public function question()
     {
-        return $this->belongsTo(Question::class);
+        return $this->belongsTo(get_class(app()->make(Question::class)));
     }
 }

--- a/src/Models/Entry.php
+++ b/src/Models/Entry.php
@@ -4,10 +4,13 @@ namespace MattDaneshvar\Survey\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\User;
+use MattDaneshvar\Survey\Contracts\Answer;
+use MattDaneshvar\Survey\Contracts\Entry as EntryContract;
+use MattDaneshvar\Survey\Contracts\Survey;
 use MattDaneshvar\Survey\Exceptions\GuestEntriesNotAllowedException;
 use MattDaneshvar\Survey\Exceptions\MaxEntriesPerUserLimitExceeded;
 
-class Entry extends Model
+class Entry extends Model implements EntryContract
 {
     /**
      * The attributes that are mass assignable.
@@ -53,7 +56,7 @@ class Entry extends Model
      */
     public function answers()
     {
-        return $this->hasMany(Answer::class);
+        return $this->hasMany(get_class(app()->make(Answer::class)));
     }
 
     /**
@@ -63,7 +66,7 @@ class Entry extends Model
      */
     public function survey()
     {
-        return $this->belongsTo(Survey::class);
+        return $this->belongsTo(get_class(app()->make(Survey::class)));
     }
 
     /**
@@ -115,7 +118,9 @@ class Entry extends Model
                 continue;
             }
 
-            $this->answers->add(Answer::make([
+            $answer_class = get_class(app()->make(Answer::class));
+
+            $this->answers->add($answer_class::make([
                 'question_id' => substr($key, 1),
                 'entry_id' => $this->id,
                 'value' => $value,

--- a/src/Models/Question.php
+++ b/src/Models/Question.php
@@ -3,8 +3,12 @@
 namespace MattDaneshvar\Survey\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use MattDaneshvar\Survey\Contracts\Answer;
+use MattDaneshvar\Survey\Contracts\Question as QuestionContract;
+use MattDaneshvar\Survey\Contracts\Section;
+use MattDaneshvar\Survey\Contracts\Survey;
 
-class Question extends Model
+class Question extends Model implements QuestionContract
 {
     /**
      * The attributes that are mass assignable.
@@ -58,7 +62,7 @@ class Question extends Model
      */
     public function survey()
     {
-        return $this->belongsTo(Survey::class);
+        return $this->belongsTo(get_class(app()->make(Survey::class)));
     }
 
     /**
@@ -68,7 +72,7 @@ class Question extends Model
      */
     public function section()
     {
-        return $this->belongsTo(Section::class);
+        return $this->belongsTo(get_class(app()->make(Section::class)));
     }
 
     /**
@@ -78,7 +82,7 @@ class Question extends Model
      */
     public function answers()
     {
-        return $this->hasMany(Answer::class);
+        return $this->hasMany(get_class(app()->make(Answer::class)));
     }
 
     /**

--- a/src/Models/Section.php
+++ b/src/Models/Section.php
@@ -3,8 +3,10 @@
 namespace MattDaneshvar\Survey\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use MattDaneshvar\Survey\Contracts\Question;
+use MattDaneshvar\Survey\Contracts\Section as SectionContract;
 
-class Section extends Model
+class Section extends Model implements SectionContract
 {
     /**
      * Section constructor.
@@ -34,6 +36,6 @@ class Section extends Model
      */
     public function questions()
     {
-        return $this->hasMany(Question::class);
+        return $this->hasMany(get_class(app()->make(Question::class)));
     }
 }

--- a/src/Models/Survey.php
+++ b/src/Models/Survey.php
@@ -3,8 +3,12 @@
 namespace MattDaneshvar\Survey\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use MattDaneshvar\Survey\Contracts\Entry;
+use MattDaneshvar\Survey\Contracts\Question;
+use MattDaneshvar\Survey\Contracts\Section;
+use MattDaneshvar\Survey\Contracts\Survey as SurveyContract;
 
-class Survey extends Model
+class Survey extends Model implements SurveyContract
 {
     /**
      * Survey constructor.
@@ -43,7 +47,7 @@ class Survey extends Model
      */
     public function sections()
     {
-        return $this->hasMany(Section::class);
+        return $this->hasMany(get_class(app()->make(Section::class)));
     }
 
     /**
@@ -53,7 +57,7 @@ class Survey extends Model
      */
     public function questions()
     {
-        return $this->hasMany(Question::class);
+        return $this->hasMany(get_class(app()->make(Question::class)));
     }
 
     /**
@@ -63,7 +67,7 @@ class Survey extends Model
      */
     public function entries()
     {
-        return $this->hasMany(Entry::class);
+        return $this->hasMany(get_class(app()->make(Entry::class)));
     }
 
     /**

--- a/src/SurveyServiceProvider.php
+++ b/src/SurveyServiceProvider.php
@@ -40,6 +40,20 @@ class SurveyServiceProvider extends ServiceProvider
     }
 
     /**
+     * Register the application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->bind(\MattDaneshvar\Survey\Contracts\Answer::class, \MattDaneshvar\Survey\Models\Answer::class);
+        $this->app->bind(\MattDaneshvar\Survey\Contracts\Entry::class, \MattDaneshvar\Survey\Models\Entry::class);
+        $this->app->bind(\MattDaneshvar\Survey\Contracts\Question::class, \MattDaneshvar\Survey\Models\Question::class);
+        $this->app->bind(\MattDaneshvar\Survey\Contracts\Section::class, \MattDaneshvar\Survey\Models\Section::class);
+        $this->app->bind(\MattDaneshvar\Survey\Contracts\Survey::class, \MattDaneshvar\Survey\Models\Survey::class);
+    }
+
+    /**
      * Publish package migrations.
      *
      * @param $migrations


### PR DESCRIPTION
Hello!

This allows a developer using this package to use a different class for any of the models.

By doing something like...

```php
$this->app->bind(\MattDaneshvar\Survey\Contracts\Answer::class, \App\Models\MyCustomAnswer::class);
```

...a user can add additional custom functionality to the model without having to alter the package's source code, fork the package, make a pull request, etc.

This doesn't change the default functionality at all and requires no updates for existing users. It just makes more options available for those that use it.

I'm doing this as I need to add an `order` field to questions so that I can re-order them after entries have already been made. To do this I need to add `order` to `fillable` on the `Question` model but I can't do that currently.