### PR TITLE
Add multiselect type

### DIFF
--- a/resources/views/questions/types/multiselect.blade.php
+++ b/resources/views/questions/types/multiselect.blade.php
@@ -1,0 +1,17 @@
+@component('survey::questions.base', compact('question'))
+    @foreach ($question->options as $option)
+        <div class="custom-control custom-checkbox">
+            <input type="checkbox"
+                   name="{{ $question->key }}[]"
+                   id="{{ $question->key . '-' . Str::slug($option) }}"
+                   value="{{ $option }}"
+                   class="custom-control-input"
+                    {{ ($value ?? old($question->key)) == $option ? 'checked' : '' }}
+                    {{ ($disabled ?? false) ? 'disabled' : '' }}
+            >
+            <label class="custom-control-label"
+                   for="{{ $question->key . '-' . Str::slug($option) }}">{{ $option }}
+            </label>
+        </div>
+    @endforeach
+@endcomponent

--- a/src/Models/Entry.php
+++ b/src/Models/Entry.php
@@ -120,6 +120,10 @@ class Entry extends Model implements EntryContract
 
             $answer_class = get_class(app()->make(Answer::class));
 
+            if (gettype($value) === 'array') {
+                $value = implode(', ', $value);
+            }
+
             $this->answers->add($answer_class::make([
                 'question_id' => substr($key, 1),
                 'entry_id' => $this->id,


### PR DESCRIPTION
Hello again!

I've added a "multiselect" field type as requested in #11 . This is basically a duplication of the radio type but using checkboxes and appending `[]` to each field so that they get processed as an array. This array is then combined into a comma-separated list before being inserted in the database.

I've removed the `$includeResults` part of the Blade file as that doesn't seem to make sense with the type of data without doing some more complex analysis. Other than that, it works well.

Cheers
Jake