### PR TITLE
Extract the logic for accessing/mutating values into casts

### DIFF
--- a/src/Casts/SeparatedByCommaAndSpace.php
+++ b/src/Casts/SeparatedByCommaAndSpace.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace MattDaneshvar\Survey\Casts;
+
+use MattDaneshvar\Survey\Contracts\Value;
+
+class SeparatedByCommaAndSpace implements Value
+{
+    /**
+     * Cast the given value.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param string $key
+     * @param mixed $value
+     * @param array $attributes
+     *
+     * @return array
+     */
+    public function get($model, $key, $value, $attributes)
+    {
+        return $value;
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param string $key
+     * @param mixed $value
+     * @param array $attributes
+     *
+     * @return string
+     */
+    public function set($model, $key, $value, $attributes)
+    {
+        if (is_array($value)) {
+            return implode(', ', $value);
+        }
+
+        return $value;
+    }
+}

--- a/src/Contracts/Value.php
+++ b/src/Contracts/Value.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MattDaneshvar\Survey\Contracts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+interface Value extends CastsAttributes
+{
+    //
+}

--- a/src/Models/Answer.php
+++ b/src/Models/Answer.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use MattDaneshvar\Survey\Contracts\Answer as AnswerContract;
 use MattDaneshvar\Survey\Contracts\Entry;
 use MattDaneshvar\Survey\Contracts\Question;
+use MattDaneshvar\Survey\Contracts\Value;
 
 class Answer extends Model implements AnswerContract
 {
@@ -19,6 +20,8 @@ class Answer extends Model implements AnswerContract
         if (! isset($this->table)) {
             $this->setTable(config('survey.database.tables.answers'));
         }
+
+        $this->casts['value'] = get_class(app(Value::class));
 
         parent::__construct($attributes);
     }

--- a/src/Models/Entry.php
+++ b/src/Models/Entry.php
@@ -120,10 +120,6 @@ class Entry extends Model implements EntryContract
 
             $answer_class = get_class(app()->make(Answer::class));
 
-            if (gettype($value) === 'array') {
-                $value = implode(', ', $value);
-            }
-
             $this->answers->add($answer_class::make([
                 'question_id' => substr($key, 1),
                 'entry_id' => $this->id,

--- a/src/SurveyServiceProvider.php
+++ b/src/SurveyServiceProvider.php
@@ -51,6 +51,7 @@ class SurveyServiceProvider extends ServiceProvider
         $this->app->bind(\MattDaneshvar\Survey\Contracts\Question::class, \MattDaneshvar\Survey\Models\Question::class);
         $this->app->bind(\MattDaneshvar\Survey\Contracts\Section::class, \MattDaneshvar\Survey\Models\Section::class);
         $this->app->bind(\MattDaneshvar\Survey\Contracts\Survey::class, \MattDaneshvar\Survey\Models\Survey::class);
+        $this->app->bind(\MattDaneshvar\Survey\Contracts\Value::class, \MattDaneshvar\Survey\Casts\SeparatedByCommaAndSpace::class);
     }
 
     /**

--- a/tests/CastingTest.php
+++ b/tests/CastingTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace MattDaneshvar\Survey\Tests;
+
+use MattDaneshvar\Survey\Models\Entry;
+use MattDaneshvar\Survey\Models\Survey;
+
+class CastingTest extends TestCase
+{
+    /** @test */
+    public function strings_are_stored_as_they_are()
+    {
+        $survey = create(Survey::class, [
+            'settings' => ['accept-guest-entries' => true]
+        ]);
+
+        $q1 = $survey->questions()->create([
+            'content' => 'Name of your cat?',
+            'type' => 'text',
+        ]);
+
+        $entry = (new Entry)
+            ->for($survey)
+            ->fromArray([$q1->id => 'Jafar']);
+
+        $entry->push();
+
+        $this->assertEquals('Jafar', $entry->answers->first()->value);
+    }
+
+    /** @test */
+    public function array_values_are_stored_as_readable_comma_separated_values()
+    {
+        $survey = create(Survey::class, [
+            'settings' => ['accept-guest-entries' => true]
+        ]);
+
+        $q1 = $survey->questions()->create([
+            'content' => 'Your favorite cat colors?',
+            'type' => 'multiselect',
+        ]);
+
+        $entry = (new Entry)
+            ->for($survey)
+            ->fromArray([$q1->id => ['Orange', 'Black']]);
+
+        $entry->push();
+
+        $this->assertEquals('Orange, Black', $entry->answers->first()->value);
+    }
+}


### PR DESCRIPTION
Prior to this PR, we always coverted array values (e.g. `['apple', 'orange']`) into comma and space separated values (e.g. `apple, orange`) before we stored them. 

This PR extracts the logic for accessing/mutating the `value` attribute of the `Answer` model, so that this behaviour can be easily customized.

Note: For backward compatiblity, we are using the same `SeparatedByCommaAndSpace` strategy as the default behaviour.

### How to customize casting after this PR
Let's assume we intend all answers to be stored as JSON. To do this, we should:
1. Create a new [Custom Cast](https://laravel.com/docs/9.x/eloquent-mutators#custom-casts). Following the example on Larave's docs: 

```php
use \MattDaneshvar\Survey\Contracts\Value;

class Json implements Value
{
    /**
     * Cast the given value.
     *
     * @param  \Illuminate\Database\Eloquent\Model  $model
     * @param  string  $key
     * @param  mixed  $value
     * @param  array  $attributes
     * @return array
     */
    public function get($model, $key, $value, $attributes)
    {
        return json_decode($value, true);
    }
 
    /**
     * Prepare the given value for storage.
     *
     * @param  \Illuminate\Database\Eloquent\Model  $model
     * @param  string  $key
     * @param  array  $value
     * @param  array  $attributes
     * @return string
     */
    public function set($model, $key, $value, $attributes)
    {
        return json_encode($value);
    }
}
```
2. Bind the new implementation to `MattDaneshvar\Survey\Contracts\Value::class`: 
```php
use \MattDaneshvar\Survey\Contracts\Value;

class AppServiceProvider extends ServiceProvider
{
    public function register()
    {
        $this->app->bind(Value::class, Json::class);
    }

    // ...
```
